### PR TITLE
Add standalone REPAS frontend SPA

### DIFF
--- a/assets/bebida.svg
+++ b/assets/bebida.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="30" y="20" width="40" height="60" fill="#e63946"/>
+  <rect x="40" y="10" width="20" height="10" fill="#000"/>
+</svg>

--- a/assets/guarnicion.svg
+++ b/assets/guarnicion.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="30" fill="#e63946"/>
+</svg>

--- a/assets/hamburguesa.svg
+++ b/assets/hamburguesa.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="10" y="40" width="80" height="20" fill="#e63946"/>
+  <rect x="10" y="60" width="80" height="15" fill="#000"/>
+  <rect x="10" y="25" width="80" height="15" fill="#000"/>
+</svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
+  <rect width="200" height="60" fill="#000"/>
+  <text x="100" y="40" font-size="40" text-anchor="middle" fill="#fff" font-family="sans-serif">REPAS</text>
+</svg>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,187 @@
+:root {
+  --color-bg: #ffffff;
+  --color-text: #000000;
+  --color-primary: #e63946;
+  --sidebar-width: 220px;
+  --transition-fast: 0.2s;
+  font-family: 'Segoe UI', Roboto, sans-serif;
+}
+
+[data-theme="dark"] {
+  --color-bg: #000000;
+  --color-text: #f5f5f5;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: var(--sidebar-width);
+  background: var(--color-text);
+  color: var(--color-bg);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 1rem 0;
+}
+.sidebar .logo {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+.sidebar .logo img {
+  max-width: 150px;
+}
+.menu {
+  display: flex;
+  flex-direction: column;
+}
+.nav-btn {
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  color: inherit;
+  text-decoration: none;
+  font-size: 1rem;
+  cursor: pointer;
+  gap: .5rem;
+}
+.nav-btn:hover,
+.nav-btn:focus {
+  background: var(--color-primary);
+  color: #fff;
+  outline: none;
+}
+.sidebar-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: .5rem;
+  padding-top: 1rem;
+}
+.clock {
+  font-size: 0.9rem;
+}
+.version {
+  font-size: 0.8rem;
+}
+
+#app {
+  flex: 1;
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+/* Cards and tables */
+.card {
+  background: var(--color-bg);
+  border: 1px solid var(--color-text);
+  padding: 1rem;
+  border-radius: 6px;
+}
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.table th, .table td {
+  border: 1px solid var(--color-text);
+  padding: .5rem;
+  text-align: left;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.modal-box {
+  background: var(--color-bg);
+  color: var(--color-text);
+  padding: 1rem;
+  max-width: 500px;
+  width: 90%;
+  border-radius: 6px;
+}
+.modal-box header {
+  font-size: 1.2rem;
+  margin-bottom: .5rem;
+}
+.modal-actions {
+  margin-top: 1rem;
+  text-align: right;
+}
+.modal-actions button {
+  margin-left: .5rem;
+}
+
+/* Grid productos */
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px,1fr));
+  gap: 1rem;
+}
+.product-card {
+  border: 1px solid var(--color-text);
+  border-radius: 6px;
+  padding: .5rem;
+  text-align: center;
+  cursor: pointer;
+}
+.product-card img {
+  max-width: 100%;
+  height: 80px;
+  object-fit: contain;
+}
+.product-card .name {
+  font-size: .9rem;
+}
+
+/* Carrito */
+.cart {
+  border-left: 2px solid var(--color-text);
+  padding-left: 1rem;
+}
+.cart-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: .5rem;
+}
+.cart-item button {
+  width: 32px;
+  height: 32px;
+}
+.cart-total {
+  font-size: 1.2rem;
+  margin-top: 1rem;
+}
+
+/* Forms */
+input, select, button {
+  font-size: 1rem;
+  padding: .5rem;
+  border: 1px solid var(--color-text);
+  border-radius: 4px;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+button {
+  cursor: pointer;
+}
+
+/* Print styles */
+@media print {
+  body { background: #fff; color: #000; }
+  .sidebar, #modal-root, #app > * { display: none !important; }
+  #print-area { display: block; }
+}
+#print-area { display: none; }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!--
+Para probar localmente: abrir este archivo en el navegador.
+Para integrar en Electron: en el proceso principal, use BrowserWindow.loadFile('index.html').
+-->
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>REPAS POS</title>
+  <link rel="stylesheet" href="css/styles.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css" />
+</head>
+<body>
+  <aside class="sidebar">
+    <div class="logo"><img src="assets/logo.svg" alt="REPAS" /></div>
+    <nav class="menu">
+      <a href="#dashboard" id="nav-dashboard" class="nav-btn"><i class="ti ti-home"></i> <span>Dashboard</span></a>
+      <a href="#vender" id="nav-vender" class="nav-btn"><i class="ti ti-shopping-cart"></i> <span>Vender</span></a>
+      <a href="#historial" id="nav-historial" class="nav-btn"><i class="ti ti-list"></i> <span>Historial</span></a>
+      <a href="#movimientos" id="nav-movimientos" class="nav-btn"><i class="ti ti-cash"></i> <span>Movimientos</span></a>
+    </nav>
+    <div class="sidebar-footer">
+      <button id="toggle-theme" class="nav-btn" aria-label="Cambiar tema"><i class="ti ti-sun"></i></button>
+      <div id="clock" class="clock">00:00:00</div>
+      <div class="version">v1.0</div>
+    </div>
+  </aside>
+  <main id="app" tabindex="-1"></main>
+  <div id="modal-root"></div>
+  <div id="print-area"></div>
+  <script type="module" src="js/app.js"></script>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,52 @@
+import {router} from './router.js';
+import {init, cajaAbierta, openCaja, setTheme, getTheme, calcularSaldoCaja} from './state.js';
+import {showModal} from './components/modal.js';
+import {toDateInputValue, formatCurrency} from './utils.js';
+
+init();
+
+// tema
+function applyTheme(){ document.body.dataset.theme = getTheme(); }
+applyTheme();
+document.getElementById('toggle-theme').addEventListener('click', ()=>{
+  const theme = getTheme()==='dark'?'light':'dark';
+  setTheme(theme);
+  applyTheme();
+});
+
+// reloj
+function updateClock(){
+  document.getElementById('clock').textContent = new Date().toLocaleTimeString('es-AR');
+}
+setInterval(updateClock,1000); updateClock();
+
+// router inicial
+router();
+
+// atajos de teclado
+window.addEventListener('keydown', e=>{
+  if(e.ctrlKey && e.key==='n'){ location.hash='#vender'; }
+  if(e.key==='F1'){ e.preventDefault(); location.hash='#dashboard'; }
+  if(e.key==='F2'){ e.preventDefault(); location.hash='#vender'; }
+  if(e.key==='F3'){ e.preventDefault(); location.hash='#historial'; }
+  if(e.key==='F4'){ e.preventDefault(); location.hash='#movimientos'; }
+});
+
+// apertura de caja si no abierta
+if(!cajaAbierta()){
+  const form = document.createElement('form');
+  form.innerHTML = `<label>Monto inicial:<br><input type="number" min="0" step="0.01" required></label>`;
+  showModal({title:'Apertura de caja', content:form, onConfirm:()=>{
+    const monto = parseFloat(form.querySelector('input').value)||0;
+    openCaja(monto); router();
+  }});
+}
+
+export function solicitarCierre(){
+  const form = document.createElement('form');
+  form.innerHTML = `<p>Saldo teórico: <strong>${formatCurrency(calcularSaldoCaja())}</strong></p><label>Monto contado:<br><input type="number" min="0" step="0.01" required></label>`;
+  showModal({title:'Cierre de caja', content:form, onConfirm:()=>{
+    const monto = parseFloat(form.querySelector('input').value)||0;
+    import('./state.js').then(m=>m.closeCaja(monto));
+  }});
+}

--- a/js/components/modal.js
+++ b/js/components/modal.js
@@ -1,0 +1,26 @@
+// Componente modal reutilizable
+export function showModal({title='', content='', onConfirm=()=>{}, onCancel=()=>{}, confirmText='Confirmar', cancelText='Cancelar'}){
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay';
+  const box = document.createElement('div');
+  box.className = 'modal-box';
+  box.innerHTML = `<header>${title}</header>`;
+  const body = document.createElement('div');
+  if(typeof content === 'string'){ body.innerHTML = content; } else { body.append(content); }
+  box.appendChild(body);
+  const actions = document.createElement('div');
+  actions.className='modal-actions';
+  const cancelBtn = document.createElement('button'); cancelBtn.textContent=cancelText;
+  const okBtn = document.createElement('button'); okBtn.textContent=confirmText;
+  actions.append(cancelBtn, okBtn);
+  box.appendChild(actions);
+  overlay.appendChild(box);
+  document.getElementById('modal-root').appendChild(overlay);
+
+  function close(){ overlay.remove(); document.removeEventListener('keydown', keyHandler); }
+  function keyHandler(e){ if(e.key==='Escape'){ onCancel(); close(); } if(e.key==='Enter'){ onConfirm(); close(); } }
+  document.addEventListener('keydown', keyHandler);
+  cancelBtn.addEventListener('click', ()=>{ onCancel(); close(); });
+  okBtn.addEventListener('click', ()=>{ onConfirm(); close(); });
+  return {close};
+}

--- a/js/router.js
+++ b/js/router.js
@@ -1,0 +1,17 @@
+import dashboard from './views/dashboard.js';
+import vender from './views/vender.js';
+import historial from './views/historial.js';
+import movimientos from './views/movimientos.js';
+
+const routes = {dashboard, vender, historial, movimientos};
+
+export function router(){
+  const hash = location.hash.slice(1) || 'dashboard';
+  const view = routes[hash] || dashboard;
+  const app = document.getElementById('app');
+  app.innerHTML='';
+  app.appendChild(view());
+  app.focus();
+}
+
+window.addEventListener('hashchange', router);

--- a/js/state.js
+++ b/js/state.js
@@ -1,0 +1,116 @@
+import {generateId} from './utils.js';
+
+const STORAGE_KEY = 'repas_state';
+let state;
+
+function seedProducts(){
+  return [
+    {id:generateId('p'), nombre:'Hamburguesa Clásica', precio:1500, categoria:'Hamburguesas', imagen:'assets/hamburguesa.svg', activo:true},
+    {id:generateId('p'), nombre:'Hamburguesa Doble', precio:2000, categoria:'Hamburguesas', imagen:'assets/hamburguesa.svg', activo:true},
+    {id:generateId('p'), nombre:'Cheeseburger', precio:1700, categoria:'Hamburguesas', imagen:'assets/hamburguesa.svg', activo:true},
+    {id:generateId('p'), nombre:'Agua', precio:600, categoria:'Bebidas', imagen:'assets/bebida.svg', activo:true},
+    {id:generateId('p'), nombre:'Gaseosa', precio:800, categoria:'Bebidas', imagen:'assets/bebida.svg', activo:true},
+    {id:generateId('p'), nombre:'Cerveza', precio:1200, categoria:'Bebidas', imagen:'assets/bebida.svg', activo:true},
+    {id:generateId('p'), nombre:'Papas Fritas', precio:900, categoria:'Guarniciones', imagen:'assets/guarnicion.svg', activo:true},
+    {id:generateId('p'), nombre:'Aros de Cebolla', precio:1000, categoria:'Guarniciones', imagen:'assets/guarnicion.svg', activo:true},
+    {id:generateId('p'), nombre:'Ensalada', precio:1100, categoria:'Guarniciones', imagen:'assets/guarnicion.svg', activo:true},
+    {id:generateId('p'), nombre:'Limonada', precio:700, categoria:'Bebidas', imagen:'assets/bebida.svg', activo:true}
+  ];
+}
+
+function load(){
+  const data = JSON.parse(localStorage.getItem(STORAGE_KEY));
+  if(data){
+    state = data;
+  }else{
+    state = {productos:seedProducts(), ventas:[], venta_items:[], movimientos:[], caja:null, theme:'light'};
+    save();
+  }
+}
+
+export function save(){
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+export function init(){
+  load();
+  return state;
+}
+
+export function getProductos(){
+  return state.productos.filter(p=>p.activo!==false);
+}
+export function addProducto(prod){
+  prod.id = generateId('p');
+  prod.activo = true;
+  state.productos.push(prod);
+  save();
+}
+export function updateProducto(prod){
+  const idx = state.productos.findIndex(p=>p.id===prod.id);
+  if(idx>-1){ state.productos[idx]=prod; save(); }
+}
+export function removeProducto(id){
+  state.productos = state.productos.filter(p=>p.id!==id);
+  save();
+}
+
+export function addVenta(venta, items){
+  venta.id = generateId('v');
+  state.ventas.push(venta);
+  items.forEach(it=>{ it.id = generateId('vi'); it.venta_id = venta.id; state.venta_items.push(it); });
+  save();
+}
+export function getVentas(){ return state.ventas; }
+export function getVentaItems(venta_id){ return state.venta_items.filter(i=>i.venta_id===venta_id); }
+export function removeVenta(id){
+  state.ventas = state.ventas.filter(v=>v.id!==id);
+  state.venta_items = state.venta_items.filter(i=>i.venta_id!==id);
+  save();
+}
+
+export function addMovimiento(mov){ mov.id=generateId('m'); state.movimientos.push(mov); save(); }
+export function getMovimientos(){ return state.movimientos; }
+
+export function openCaja(monto){ state.caja={fecha_aperturaISO:new Date().toISOString(), monto_inicial:monto}; save(); }
+export function closeCaja(montoContado){
+  const saldo = calcularSaldoCaja();
+  state.caja.fecha_cierreISO=new Date().toISOString();
+  state.caja.monto_contado=montoContado;
+  state.caja.diferencia=montoContado - saldo;
+  save();
+}
+export function cajaAbierta(){ return state.caja && !state.caja.fecha_cierreISO; }
+export function getCaja(){ return state.caja; }
+
+export function ventasDelDia(){
+  const hoy = new Date().toISOString().slice(0,10);
+  return state.ventas.filter(v=>v.fechaISO.slice(0,10)===hoy);
+}
+export function totalDelDia(){
+  return ventasDelDia().reduce((s,v)=>s+v.total,0);
+}
+export function productoMasVendido(){
+  const items = ventasDelDia().flatMap(v=>getVentaItems(v.id));
+  if(items.length===0) return 'N/A';
+  const tot = {};
+  items.forEach(i=>{ tot[i.nombre]=(tot[i.nombre]||0)+i.cantidad; });
+  return Object.entries(tot).sort((a,b)=>b[1]-a[1])[0][0];
+}
+export function ventasPorHora(){
+  const arr = Array(24).fill(0);
+  ventasDelDia().forEach(v=>{ const h=new Date(v.fechaISO).getHours(); arr[h]+=v.total; });
+  return arr;
+}
+
+export function calcularSaldoCaja(){
+  if(!state.caja) return 0;
+  const apertura = state.caja.monto_inicial;
+  const ventasEfe = state.ventas.filter(v=>v.metodo_pago==='efectivo').reduce((s,v)=>s+v.total,0);
+  const ingresosEfe = state.movimientos.filter(m=>m.tipo==='ingreso' && m.medio==='efectivo').reduce((s,m)=>s+m.monto,0);
+  const egresosEfe = state.movimientos.filter(m=>m.tipo==='egreso' && m.medio==='efectivo').reduce((s,m)=>s+m.monto,0);
+  return apertura + ventasEfe + ingresosEfe - egresosEfe;
+}
+
+export function setTheme(t){ state.theme=t; save(); }
+export function getTheme(){ return state.theme || 'light'; }

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,24 @@
+// Utilidades generales
+export const formatCurrency = (v) => new Intl.NumberFormat('es-AR', {style:'currency', currency:'ARS'}).format(v);
+
+export const generateId = (prefix='id') => `${prefix}_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+
+export function exportCSV(filename, rows) {
+  const csv = rows.map(r => r.map(field => '"' + String(field).replace(/"/g,'""') + '"').join(',')).join('\n');
+  const blob = new Blob([csv], {type:'text/csv'});
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+export function printTicket(html) {
+  const area = document.getElementById('print-area');
+  area.innerHTML = html;
+  setTimeout(() => window.print(), 100);
+}
+
+export function toDateInputValue(date){
+  return date.toISOString().split('T')[0];
+}

--- a/js/views/dashboard.js
+++ b/js/views/dashboard.js
@@ -1,0 +1,25 @@
+import {ventasDelDia, totalDelDia, productoMasVendido, ventasPorHora} from '../state.js';
+import {formatCurrency} from '../utils.js';
+
+export default function dashboard(){
+  const div = document.createElement('div');
+  const ventas = ventasDelDia();
+  div.innerHTML = `
+    <h1>Dashboard</h1>
+    <div class="kpis" style="display:flex;gap:1rem;flex-wrap:wrap;">
+      <div class="card">Ventas del día: <strong>${ventas.length}</strong></div>
+      <div class="card">Total del día: <strong>${formatCurrency(totalDelDia())}</strong></div>
+      <div class="card">Producto más vendido: <strong>${productoMasVendido()}</strong></div>
+    </div>
+    <canvas id="ventas-horas" width="600" height="120"></canvas>
+  `;
+  const canvas = div.querySelector('#ventas-horas');
+  const ctx = canvas.getContext('2d');
+  const data = ventasPorHora();
+  const max = Math.max(...data, 10);
+  const w = canvas.width, h=canvas.height;
+  const barWidth = w/data.length;
+  ctx.fillStyle = '#e63946';
+  data.forEach((v,i)=>{ const barHeight = (v/max)*h; ctx.fillRect(i*barWidth, h-barHeight, barWidth-2, barHeight); });
+  return div;
+}

--- a/js/views/historial.js
+++ b/js/views/historial.js
@@ -1,0 +1,54 @@
+import {getVentas, getVentaItems, removeVenta} from '../state.js';
+import {formatCurrency, exportCSV, toDateInputValue} from '../utils.js';
+import {showModal} from '../components/modal.js';
+
+export default function historial(){
+  const div = document.createElement('div');
+  const hoy = new Date();
+  div.innerHTML = `
+    <h1>Historial</h1>
+    <div style="display:flex;gap:.5rem;flex-wrap:wrap;margin-bottom:.5rem;">
+      <input type="date" id="filtro-fecha" value="${toDateInputValue(hoy)}">
+      <input type="text" id="buscar-id" placeholder="Buscar por id">
+      <button id="btn-export">Exportar CSV</button>
+    </div>
+    <table class="table" id="tabla-ventas">
+      <thead><tr><th>Hora</th><th>Método</th><th>Total</th><th></th></tr></thead>
+      <tbody></tbody>
+    </table>
+  `;
+  const tbody = div.querySelector('tbody');
+
+  function render(){
+     const fecha = div.querySelector('#filtro-fecha').value;
+     const search = div.querySelector('#buscar-id').value;
+     tbody.innerHTML='';
+     getVentas().filter(v=>v.fechaISO.slice(0,10)===fecha && (!search || v.id.includes(search))).forEach(v=>{
+        const tr=document.createElement('tr');
+        tr.innerHTML=`<td>${new Date(v.fechaISO).toLocaleTimeString('es-AR')}</td><td>${v.metodo_pago}</td><td>${formatCurrency(v.total)}</td><td><button data-ver>Ver</button> <button data-del>Eliminar</button></td>`;
+        tr.querySelector('[data-ver]').addEventListener('click',()=>mostrarVenta(v));
+        tr.querySelector('[data-del]').addEventListener('click',()=>{ if(confirm('Eliminar venta?')){ removeVenta(v.id); render(); } });
+        tbody.appendChild(tr);
+     });
+  }
+
+  function mostrarVenta(v){
+     const items = getVentaItems(v.id);
+     let html = `<p>ID: ${v.id}</p><p>${new Date(v.fechaISO).toLocaleString('es-AR')}</p><table class="table"><tr><th>Producto</th><th>Cant</th><th>Subtotal</th></tr>`;
+     items.forEach(i=>{ html+=`<tr><td>${i.nombre}</td><td>${i.cantidad}</td><td>${formatCurrency(i.subtotal)}</td></tr>`; });
+     html+=`<tr><td colspan="2">Total</td><td>${formatCurrency(v.total)}</td></tr></table>`;
+     showModal({title:'Venta',content:html,confirmText:'Cerrar',cancelText:'Eliminar',onCancel:()=>{ if(confirm('Eliminar venta?')){ removeVenta(v.id); render(); }} });
+  }
+
+  div.querySelector('#filtro-fecha').addEventListener('change',render);
+  div.querySelector('#buscar-id').addEventListener('input',render);
+  div.querySelector('#btn-export').addEventListener('click',()=>{
+    const fecha=div.querySelector('#filtro-fecha').value;
+    const rows=[[ 'id','fecha','metodo','total']];
+    getVentas().filter(v=>v.fechaISO.slice(0,10)===fecha).forEach(v=>rows.push([v.id,v.fechaISO,v.metodo_pago,v.total]));
+    exportCSV('ventas_'+fecha+'.csv', rows);
+  });
+
+  render();
+  return div;
+}

--- a/js/views/movimientos.js
+++ b/js/views/movimientos.js
@@ -1,0 +1,46 @@
+import {getMovimientos, addMovimiento, calcularSaldoCaja} from '../state.js';
+import {formatCurrency} from '../utils.js';
+
+export default function movimientos(){
+  const div = document.createElement('div');
+  div.innerHTML=`
+    <h1>Movimientos</h1>
+    <form id="mov-form" style="display:flex;gap:.5rem;flex-wrap:wrap;margin-bottom:1rem;">
+      <select name="tipo" required><option value="ingreso">Ingreso</option><option value="egreso">Egreso</option></select>
+      <select name="medio" required><option value="efectivo">Efectivo</option><option value="debito">Débito</option><option value="transferencia">Transferencia</option></select>
+      <input name="monto" type="number" min="0" step="0.01" placeholder="Monto" required>
+      <input name="motivo" placeholder="Motivo" required>
+      <input name="referencia" placeholder="Referencia">
+      <button type="submit">Agregar</button>
+    </form>
+    <button id="btn-cierre">Cerrar caja</button>
+    <table class="table"><thead><tr><th>Hora</th><th>Tipo</th><th>Medio</th><th>Monto</th><th>Motivo</th></tr></thead><tbody></tbody></table>
+    <div id="totales"></div>
+  `;
+  const tbody = div.querySelector('tbody');
+
+  function render(){
+     const fecha = new Date().toISOString().slice(0,10);
+     tbody.innerHTML='';
+     const movimientos = getMovimientos().filter(m=>m.fechaISO.slice(0,10)===fecha);
+     movimientos.forEach(m=>{
+       const tr=document.createElement('tr');
+       tr.innerHTML=`<td>${new Date(m.fechaISO).toLocaleTimeString('es-AR')}</td><td>${m.tipo}</td><td>${m.medio}</td><td>${formatCurrency(m.monto)}</td><td>${m.motivo}</td>`;
+       tbody.appendChild(tr);
+     });
+     div.querySelector('#totales').innerHTML = `Saldo efectivo: <strong>${formatCurrency(calcularSaldoCaja())}</strong>`;
+  }
+
+  div.querySelector('#mov-form').addEventListener('submit',e=>{
+     e.preventDefault();
+     const fd=new FormData(e.target);
+     addMovimiento({fechaISO:new Date().toISOString(), tipo:fd.get('tipo'), medio:fd.get('medio'), monto:parseFloat(fd.get('monto')), motivo:fd.get('motivo'), referencia:fd.get('referencia')});
+     e.target.reset();
+     render();
+  });
+
+  div.querySelector('#btn-cierre').addEventListener('click',()=>import('../app.js').then(m=>m.solicitarCierre()));
+
+  render();
+  return div;
+}

--- a/js/views/vender.js
+++ b/js/views/vender.js
@@ -1,0 +1,120 @@
+import {getProductos, addProducto, updateProducto, removeProducto, addVenta} from '../state.js';
+import {formatCurrency, printTicket} from '../utils.js';
+import {showModal} from '../components/modal.js';
+
+export default function vender(){
+  const div = document.createElement('div');
+  div.innerHTML = `
+    <h1>Vender</h1>
+    <div style="display:flex;gap:1rem;">
+      <div style="flex:2;">
+        <div style="display:flex;gap:.5rem;margin-bottom:.5rem;flex-wrap:wrap;">
+          <input type="text" placeholder="Buscar" id="buscar-prod"/>
+          <select id="filtro-cat">
+            <option value="">Todas</option>
+            <option>Hamburguesas</option>
+            <option>Bebidas</option>
+            <option>Guarniciones</option>
+          </select>
+          <button id="btn-add-prod">Agregar producto</button>
+        </div>
+        <div class="product-grid" id="grid-prod"></div>
+      </div>
+      <div style="flex:1;" class="cart" id="cart"></div>
+    </div>
+  `;
+  const grid = div.querySelector('#grid-prod');
+  const cartDiv = div.querySelector('#cart');
+  let cart = [];
+
+  function renderProductos(){
+    const texto = div.querySelector('#buscar-prod').value.toLowerCase();
+    const cat = div.querySelector('#filtro-cat').value;
+    grid.innerHTML='';
+    getProductos().filter(p=>p.nombre.toLowerCase().includes(texto) && (!cat || p.categoria===cat)).forEach(p=>{
+       const card=document.createElement('div');
+       card.className='product-card';
+       card.style.position='relative';
+       card.innerHTML=`<img src="${p.imagen}" alt=""><div class="name">${p.nombre}</div><div>${formatCurrency(p.precio)}</div>`;
+       card.addEventListener('click',()=>addToCart(p));
+       const edit=document.createElement('button'); edit.textContent='✎'; edit.style.position='absolute'; edit.style.top='2px'; edit.style.right='2px';
+       edit.addEventListener('click',e=>{e.stopPropagation(); editarProducto(p);});
+       const del=document.createElement('button'); del.textContent='🗑'; del.style.position='absolute'; del.style.bottom='2px'; del.style.right='2px';
+       del.addEventListener('click',e=>{e.stopPropagation(); if(confirm('Eliminar producto?')){ removeProducto(p.id); renderProductos(); }});
+       card.append(edit, del);
+       grid.appendChild(card);
+    });
+  }
+
+  function editarProducto(p){
+    const form=document.createElement('form');
+    form.innerHTML=`<label>Nombre<br><input name="nombre" value="${p.nombre}" required></label><br><label>Precio<br><input name="precio" type="number" min="0" step="0.01" value="${p.precio}" required></label><br><label>Categoría<br><input name="categoria" value="${p.categoria}" required></label><br><label>Imagen URL<br><input name="imagen" value="${p.imagen}"></label>`;
+    showModal({title:'Editar producto',content:form,onConfirm:()=>{
+       const fd=new FormData(form);
+       updateProducto({id:p.id,nombre:fd.get('nombre'),precio:parseFloat(fd.get('precio')),categoria:fd.get('categoria'),imagen:fd.get('imagen'),activo:true});
+       renderProductos();
+    }});
+  }
+
+  function addToCart(prod){
+     const existing = cart.find(i=>i.producto_id===prod.id);
+     if(existing){ existing.cantidad++; existing.subtotal=existing.cantidad*existing.precio_unit; }
+     else cart.push({producto_id:prod.id, nombre:prod.nombre, precio_unit:prod.precio, cantidad:1, subtotal:prod.precio});
+     renderCart();
+  }
+
+  function renderCart(){
+    cartDiv.innerHTML='<h3>Carrito</h3>';
+    cart.forEach((item,idx)=>{
+       const row=document.createElement('div'); row.className='cart-item';
+       row.innerHTML=`<span>${item.nombre} (${formatCurrency(item.precio_unit)})</span><div><button data-action="-">-</button><span>${item.cantidad}</span><button data-action="+">+</button><button data-action="del">x</button></div>`;
+       row.querySelector('[data-action="+"]').addEventListener('click',()=>{item.cantidad++;item.subtotal=item.cantidad*item.precio_unit;renderCart();});
+       row.querySelector('[data-action="-"]').addEventListener('click',()=>{item.cantidad--;if(item.cantidad<=0) cart.splice(idx,1); else item.subtotal=item.cantidad*item.precio_unit;renderCart();});
+       row.querySelector('[data-action="del"]').addEventListener('click',()=>{cart.splice(idx,1);renderCart();});
+       cartDiv.appendChild(row);
+    });
+    const subtotal = cart.reduce((s,i)=>s+i.subtotal,0);
+    const totalDiv=document.createElement('div'); totalDiv.className='cart-total'; totalDiv.textContent='Total: '+formatCurrency(subtotal); cartDiv.appendChild(totalDiv);
+    const actions=document.createElement('div'); actions.innerHTML='<button id="btn-cobrar">Cobrar</button> <button id="btn-cancelar">Cancelar</button>'; cartDiv.appendChild(actions);
+    cartDiv.querySelector('#btn-cancelar').addEventListener('click',()=>{cart=[];renderCart();});
+    cartDiv.querySelector('#btn-cobrar').addEventListener('click', cobrar);
+  }
+
+  function cobrar(){
+     if(cart.length===0) return;
+     const form=document.createElement('form');
+     form.innerHTML=`<label>Método de pago<select name="metodo"><option value="efectivo">Efectivo</option><option value="debito">Débito</option><option value="transferencia">Transferencia</option></select></label><br><label><input type="checkbox" name="comanda"> Imprimir comanda</label>`;
+     showModal({title:'Cobro', content:form, onConfirm:()=>{
+        const data=new FormData(form);
+        const venta={fechaISO:new Date().toISOString(), subtotal:cart.reduce((s,i)=>s+i.subtotal,0), descuento:0,total:cart.reduce((s,i)=>s+i.subtotal,0), metodo_pago:data.get('metodo'), imprimir_comanda:data.get('comanda')==='on'};
+        addVenta(venta, cart.map(i=>({...i})));
+        const html = ticketHTML(venta,cart);
+        printTicket(html);
+        if(venta.imprimir_comanda) printTicket(html);
+        cart=[]; renderCart();
+     }});
+  }
+
+  function ticketHTML(venta,items){
+     let html = `<h1>REPAS</h1><p>${new Date(venta.fechaISO).toLocaleString('es-AR')}</p><table style="width:100%;">`;
+     items.forEach(i=>{html+=`<tr><td>${i.cantidad} x ${i.nombre}</td><td style="text-align:right;">${formatCurrency(i.subtotal)}</td></tr>`;});
+     html+=`<tr><td>Total</td><td style="text-align:right;">${formatCurrency(venta.total)}</td></tr></table>`;
+     return html;
+  }
+
+  div.querySelector('#buscar-prod').addEventListener('input',renderProductos);
+  div.querySelector('#filtro-cat').addEventListener('change',renderProductos);
+  div.querySelector('#btn-add-prod').addEventListener('click',()=>{
+     const form=document.createElement('form');
+     form.innerHTML=`<label>Nombre<br><input name="nombre" required></label><br><label>Precio<br><input name="precio" type="number" min="0" step="0.01" required></label><br><label>Categoría<br><input name="categoria" required></label><br><label>Imagen URL<br><input name="imagen"></label>`;
+     showModal({title:'Agregar producto',content:form,onConfirm:()=>{
+        const fd=new FormData(form);
+        addProducto({nombre:fd.get('nombre'),precio:parseFloat(fd.get('precio')),categoria:fd.get('categoria'),imagen:fd.get('imagen')||'assets/hamburguesa.svg'});
+        renderProductos();
+     }});
+  });
+
+  renderProductos();
+  renderCart();
+  return div;
+}


### PR DESCRIPTION
## Summary
- Build static REPAS POS SPA in vanilla HTML, CSS, and JS.
- Implement hash-based routing and state management with localStorage.
- Add product sales flow, history listing, and cash movement tracking with modal dialogs.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af678e90e08326bf76822d1b153a8e